### PR TITLE
Add 'Meet DocC documentation in Xcode'

### DIFF
--- a/content/notes/wwdc21/10166.md
+++ b/content/notes/wwdc21/10166.md
@@ -1,0 +1,25 @@
+---
+contributors: Jeehut
+originalURL: https://www.notion.so/papershift/Cihat-WWDC-2021-Notes-6cae8d046c17426f8dafddc00abdae29
+---
+
+- Allows to write code reference docs
+- Allows to write articles with code
+- Allows to write tutorials, much deeper than reference / articles
+- Will be released as open source later this year
+- Compiler provides code details, also includes DocC Catalog & builds DocC Archive
+- 3 ways to build documentation:
+    - Menu: “Build Documentation” on demand
+    - Swift Frameworks can be previewed via setting “Build Documentation during ‘Build’”
+    - `xcodebuild docbuild` for the command line (e.g. on CI)
+- Xcode supports opening the DocC Archive in a nice GUI with navigation & search (called Documentation Viewer)
+- Documentation is written in-source, via `///` doc domments
+- DocC only generates documentation for code marked as `public` or `open`
+- Code examples can be added via Markdown code syntax via 3 backticks (```swift)
+- New “Open in Developer Documentation” link in any QuickHelp menu (Option + Click)
+- Prefer `Parameters` over `Parameter` for multiple parameters for method docs
+- Option+Click and choose “Add Documentation” to auto-generate documentation template
+- New double-backtick syntax to inter-link between different documented elements
+- For fields of different types, use `/` as in ``Habitat/child``, includes auto-completion
+- Xcode exports an archive which is a "single page web app", can be shared to Web easily
+- Export via (…) menu, file extension is `.doccarchive`


### PR DESCRIPTION
Originally shared at:
https://www.notion.so/papershift/Cihat-WWDC-2021-Notes-6cae8d046c17426f8dafddc00abdae29