### PR TITLE
Add 'Meet Textkit 2' (incomplete)

### DIFF
--- a/content/notes/wwdc21/10061.md
+++ b/content/notes/wwdc21/10061.md
@@ -1,0 +1,18 @@
+---
+contributors: Jeehut
+originalURL: https://www.notion.so/papershift/Cihat-WWDC-2021-Notes-6cae8d046c17426f8dafddc00abdae29
+---
+
+- Text controls in the system are based on TextKit 1
+- Started in OpenStep even before first version of Mac OS
+- TextKit 2 is built on forward-looking design principles, used on macOS since v11
+- TextKit 2 will coexist with TextKit 1 (for now), many new classes added, some updated
+- Principles designed by:
+    - Correctness: abstract away glyph handling
+    - Safety: heavier focus on value semantics
+    - Performance: viewport-based layout and rendering
+- Glyph: Visual representation of a variable number of characters, e.g. ñ is 2 glyphs
+- Ligature: Single glyph representing multiple characters
+- Glyph ranges were impossible to use right in many languages, TextKit 2 simplifies it
+- In TextKit 2 all text is rendered with CoreText, no glyph ranges needed, higher level objects like `NSTextSelection`, `NSTextSelectionNavigation`
+- Contributor comment: *didn't continue watching from here as too low-level/irrelevant for me*


### PR DESCRIPTION
Originally shared at:
https://www.notion.so/papershift/Cihat-WWDC-2021-Notes-6cae8d046c17426f8dafddc00abdae29

@zntfdr I'm not sure if this should be merged as is as I didn't watch the session to the end (see my last entry). Added because maybe the start is better than nothing, but your choice. I can understand if you don't want to merge to keep the session marked as "no notes yet".