### PR TITLE
Add 'Tap into Game Center: Dashboard, Access Point, and Profile'

### DIFF
--- a/content/notes/wwdc20/10618.md
+++ b/content/notes/wwdc20/10618.md
@@ -1,0 +1,15 @@
+---
+contributors: Jeehut
+originalURL: https://www.notion.so/papershift/Cihat-WWDC-2020-Notes-5891eff2d250446f914110f8f008925d
+---
+
+- Most features can be used with custom UI, too (using API)
+- New interface if using default interface
+- Player avatar should be in title screen, notifications will be automatically shown (e.g. for new achievements)
+- In-Game-Dashboard contains profile, achievements & leaderboards
+- In-Progress Achievements available, achievement art can and should be provided
+- Leaderboard art highlighted more, again should be provided
+- "Current leaderboard" available, updates live
+- Optional "challenges" dashboard available, will not appear by default
+- Custom multiplayer UI & default UI available
+- Contributor comment: *skipped the implementation part of the session*


### PR DESCRIPTION
Originally shared at:
https://www.notion.so/papershift/Cihat-WWDC-2020-Notes-5891eff2d250446f914110f8f008925d

@zntfdr This is also kind of incomplete as I skipped the implementation part. Feel free to not merge, your choice.