### PR TITLE
Remove incorrect disclaimer about tuple layout

### DIFF
--- a/content/notes/wwdc20/10167.md
+++ b/content/notes/wwdc20/10167.md
@@ -336,7 +336,6 @@ func testPointingToTuple() {
 * Construct a raw pointer deliberately erasing the type of tuple pointer.
 * Use `assumingMemoryBound` to create a pointer to `Int`. 
 * Homogeneous tuples have guaranteed layout. (one value after another)
-* ⚠️ Tuples with different types have no layout guarantee.
 
 #### Pointing to struct properties
 


### PR DESCRIPTION
Tuples guarantee in-order, naturally aligned layout when observable.